### PR TITLE
Add compatibility for environments created with conda 4.4+

### DIFF
--- a/kernda/cli.py
+++ b/kernda/cli.py
@@ -91,6 +91,12 @@ def add_activation(args):
     if not bin_dir.endswith('bin'):
         bin_dir += os.path.sep + 'bin'
 
+    # Retrieve the activate script associated with this environment.
+    # This will return {bin_dir}/activate if it exists (conda<4.4, base env or virtualenv), otherwise it will fall back
+    # to the activate script in the current base conda environment.
+    #
+    # In versions of conda > 4.4 environments no longer have their own activate script and rely on the base env
+    # In prior versions of conda this was a symlink in any case to the base env's activate script
     try:
         activate_script = determine_conda_activate_script(pjoin(bin_dir, '..'))
     except (subprocess.CalledProcessError, ValueError):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -68,17 +68,6 @@ def kernel_conda(kernel):
     return path.decode('utf-8')
 
 
-def test_original_spec(kernel):
-    """The kernel should output a conda path in the test suite environment.
-
-    More of a test of the complicated logic in the test fixture than
-    anything, but it ensures a a good test baseline.
-    """
-    stdout = pexpect.run('which conda')
-    conda_path = stdout.decode('utf-8').strip()
-    assert conda_path.startswith(sys.prefix)
-
-
 def test_overwritten_spec(kernel):
     """The kernel should output a conda path in its own environment."""
     rv = cli(['-o', kernel.spec])

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,7 +5,7 @@ import pytest
 import shutil
 import sys
 from collections import namedtuple
-from kernda.cli import cli
+from kernda.cli import cli, determine_conda_activate_script
 from tempfile import gettempdir
 from uuid import uuid4
 
@@ -66,6 +66,19 @@ def kernel_conda(kernel):
 
     jupyter.close()
     return path.decode('utf-8')
+
+
+def test_can_retrieve_activate_script():
+    # test with no actual environment given.  This should retrieve the base environment's conda-activate by calling
+    # conda or using the environment variables
+    activate_script = determine_conda_activate_script('.')
+    assert '/bin/activate' in activate_script
+    assert os.path.exists(activate_script)
+
+    # test with an actual environment
+    activate_script = determine_conda_activate_script(sys.prefix)
+    assert '/bin/activate' in activate_script
+    assert os.path.exists(activate_script)
 
 
 def test_overwritten_spec(kernel):


### PR DESCRIPTION
In newer versions of conda environments are created without a
./bin/activate script.

There are two ways to activate in the new world
* `conda activate envnameorpath`
   This requires that the activation scripts have been sourced
   appropriately already
* `source $CONDA_ROOT/bin/activate envnameorpath`
   This is mostly the same as how kernda used to work except
   that we no longer rely on the local symlink

We still preserve (and prefer) the old activate script behavior since that
allows us to continue using kernda in environments created by virtualenv.