### PR TITLE
Update ci to drop 3.4 and pick up 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
+- 3.7
 
 before_install:
 - git clone https://github.com/ericdill/ci ~/scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-language: python
-
+sudo: false
+dist: trusty
 matrix:
   include:
     - name: "Python 2.7 unit tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,22 @@ language: python
 
 matrix:
   include:
-    PYTHON_VERSION:
-      - 2.7
-      - 3.5
-      - 3.6
-      - 3.7
+    - name: "Python 2.7 unit tests"
+      env: PYTHON=2.7
+    - name: "Python 3.5 unit tests"
+      env: PYTHON=3.5
+    - name: "Python 3.6 unit tests"
+      env: PYTHON=3.6
+    - name: "Python 3.7 unit tests"
+      env: PYTHON=3.7
 
 before_install:
 - git clone https://github.com/ericdill/ci ~/scripts
 
 install:
 - . ~/scripts/install-miniconda.sh
-- conda create -n testenv-$PYTHON_VERSION python=$PYTHON_VERSION pip
-- source activate testenv-$PYTHON_VERSION
+- conda create -n testenv-$PYTHON python=$PYTHON pip
+- source activate testenv-$PYTHON
 - pip install -r test-requirements.txt
 - pip install codecov
 - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: python
 
-python:
-- 2.7
-- 3.5
-- 3.6
-- 3.7
+matrix:
+  include:
+    PYTHON_VERSION:
+      - 2.7
+      - 3.5
+      - 3.6
+      - 3.7
 
 before_install:
 - git clone https://github.com/ericdill/ci ~/scripts
 
 install:
 - . ~/scripts/install-miniconda.sh
-- conda create -n testenv-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION pip
-- source activate testenv-$TRAVIS_PYTHON_VERSION
+- conda create -n testenv-$PYTHON_VERSION python=$PYTHON_VERSION pip
+- source activate testenv-$PYTHON_VERSION
 - pip install -r test-requirements.txt
 - pip install codecov
 - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ before_install:
 
 install:
 - . ~/scripts/install-miniconda.sh
-- conda create -n testenv-$PYTHON python=$PYTHON pip
+- conda create -n testenv-$PYTHON python=$PYTHON pip --file test-requirements.txt
 - source activate testenv-$PYTHON
-- pip install -r test-requirements.txt
 - pip install codecov
 - pip install -e .
 


### PR DESCRIPTION
@parente I used to ship a `run_tests.py` file that turned on/off coverage manually. Does that live somewhere in one of the internal repos that we owned at MaxPoint? I'd like to include one of those `run_tests.py` files here. Otherwise I have to remember the `coverage` syntax. #lazy